### PR TITLE
Kubeadm v1.5 instructions

### DIFF
--- a/docs/cluster-setup-guide/cluster-setup-guide-cluster-installation.rst
+++ b/docs/cluster-setup-guide/cluster-setup-guide-cluster-installation.rst
@@ -1,4 +1,4 @@
-.. _my-cluster-setup: 
+.. _my-cluster-setup:
 
 Cluster installation
 ====================
@@ -6,7 +6,7 @@ Cluster installation
 Overview
 --------
 
-As a reminder, in this example, this is our cluster setup: 
+As a reminder, in this example, this is our cluster setup:
 
 ==================  ====================  ====================  ============
      Hostname           Management IP        Kubernetes IP          Role
@@ -26,7 +26,7 @@ To install Kubernetes on our ubuntu systems, we will leverage **kubeadm**
 Here are the steps that are involved (detailed later):
 
 1. make sure that firewalld is disabled (not supported today with kubeadm)
-2. disable Apparmor 
+2. disable Apparmor
 3. install docker if not already done (many kubernetes services will run into containers for reliability)
 4. install kubernetes packages
 
@@ -43,34 +43,33 @@ to make sure the systems are up to date, run this command on **all systems**:
 installation
 -------------
 
-You need **root privileges** for this section, either use sudo or su to gain the required privileges. 
+You need **root privileges** for this section, either use sudo or su to gain the required privileges.
 
 you need to give access to the kubernetes packages to your systems, do this on **all systems**:
 
 ::
 
-	apt-get update && apt-get install -y apt-transport-https
+    apt-get update && apt-get install -y apt-transport-https
+    curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
+    cat <<EOF >/etc/apt/sources.list.d/kubernetes.list
+    deb http://apt.kubernetes.io/ kubernetes-xenial main
+    EOF
+    apt-get update
 
-	curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
-	
-	cat <<EOF > /etc/apt/sources.list.d/kubernetes.list
-	deb http://apt.kubernetes.io/ kubernetes-xenial main
-	EOF
+    sudo apt-get -y install kubectl=1.5.3-00 kubelet=1.5.3-00 kubernetes-cni=0.3.0.1-07a8a2-00
 
-	apt-get update
+    curl -Lo /tmp/old-kubeadm.deb https://apt.k8s.io/pool/kubeadm_1.6.0-alpha.0.2074-a092d8e0f95f52-00_amd64_0206dba536f698b5777c7d210444a8ace18f48e045ab78687327631c6c694f42.deb
+    sudo dpkg -i /tmp/old-kubeadm.deb
+    sudo apt-get install -f
+
+    sudo apt-mark hold kubeadm kubectl kubelet kubernetes-cni
 
 once this is done, install docker if not already done on **all systems**:
 
 ::
 
-	apt-get install -y docker.io 
+	apt-get install -y docker.io
 
-then install our needed kubernetes packages on **all systems**:
-
-::
-
-	apt-get install -y kubelet kubeadm kubectl kubernetes-cni
-	
 
 Limitations
 -----------

--- a/docs/cluster-setup-guide/cluster-setup-guide-master-setup.rst
+++ b/docs/cluster-setup-guide/cluster-setup-guide-master-setup.rst
@@ -12,12 +12,12 @@ to setup **master** as a Kubernetes *master*, run the following command:
 
 ::
 
-	sudo kubeadm init --api-advertise-addresses=10.1.10.11
+	sudo kubeadm init --api-advertise-addresses=10.1.10.11 --use-kubernetes-version=v1.5.3
 
 Here we specify:
 
-* The IP address that should be used to advertise the master. 10.1.10.0/24 is the network for our controle plane. if you don't specify the --api-advertise-addresses argument, kubeadm will pick the first interface with a default gateway (because it needs internet access). 
-  
+* The IP address that should be used to advertise the master. 10.1.10.0/24 is the network for our controle plane. if you don't specify the --api-advertise-addresses argument, kubeadm will pick the first interface with a default gateway (because it needs internet access).
+
 When running the command you should see something like this:
 
 .. image:: ../images/cluster-setup-guide-kubeadm-init-master.png
@@ -38,7 +38,7 @@ This is the command to run on the node so that it registers itself with the mast
 
 	**save this command somewhere since you'll need it later**
 
-You can monitor that the services start to run by using the command: 
+You can monitor that the services start to run by using the command:
 
 ::
 
@@ -47,7 +47,7 @@ You can monitor that the services start to run by using the command:
 .. image:: ../images/cluster-setup-guide-kubeadmin-init-check.png
 	:align: center
 
-kube-dns won't start until the network pod is setup. 
+kube-dns won't start until the network pod is setup.
 
 Network pod
 -----------
@@ -59,18 +59,18 @@ You must install a *pod* network add-on so that your *pods* can communicate with
 Here is the list of add-ons available:
 
 * Calico
-* Canal 
-* Flannel 
+* Canal
+* Flannel
 * Romana
 * Weave net
 
-We will use Weave net as mentioned previously. To set Weave net as a network pod, you may use the command: 
+We will use Weave net as mentioned previously. To set Weave net as a network pod, you may use the command:
 
 ::
 
 	kubectl apply -f https://git.io/weave-kube
 
-you should see something like this: 
+you should see something like this:
 
 ::
 
@@ -78,7 +78,7 @@ you should see something like this:
 
 
 
-check master state 
+check master state
 ------------------
 
 If everything runs as expected you should have kube-dns that started successfully. To check the status of the different service, you can run the command:
@@ -90,14 +90,14 @@ If everything runs as expected you should have kube-dns that started successfull
 The output should show all services as running
 
 .. image:: ../images/cluster-setup-guide-kubeadmin-init-check-cluster-get-pods.png
-	:align: center 
+	:align: center
 
 
 
 kubectl get pods --all-namespaces
 
-:: 
-	
+::
+
 	kubectl get cs
 
 .. image:: ../images/cluster-setup-guide-kubeadmin-init-check-cluster.png
@@ -105,7 +105,7 @@ kubectl get pods --all-namespaces
 
 
 ::
-	
+
 	kubectl cluster-info
 
 .. image:: ../images/cluster-setup-guide-kubeadmin-init-check-cluster-info.png


### PR DESCRIPTION
Modified cluster installation instructions to install kubernetes v1.5 to avoid running into RBAC issues in v1.6 until CC is validated and supports k8s v1.6. 